### PR TITLE
nixsa-bin: env var to append bwrap args

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ In addition, after the command finishes, the `nixsa` executable looks at the cur
 
 In order to allow upgrades of the `nixsa` executable itself, `nixsa-dir/bin/nixsa` is a symlink to `../nix/store/HASH-nixsa-bin-VERSION/bin/nixsa`. If you update the `nixsa-bin` package in the profile, Nixsa will update the `nixsa-dir/bin/nixsa` symlink accordingly.
 
+## Environment variables
+
+Nixsa supports the following environment variables to fine tune its behavior.
+- `NIXSA_BWRAP_ARGS` extra arguments appended to the computed `bwrap` command line.
+
 ## Comparison to other tools
 
 Nixsa is very similar in its purpose to [nix-portable](https://github.com/DavHau/nix-portable). The main differences that I see are:

--- a/nixsa-bin/src/main.rs
+++ b/nixsa-bin/src/main.rs
@@ -60,6 +60,9 @@ fn get_bwrap_prefix(nixpath: &Utf8Path) -> Result<Vec<String>> {
             args.extend(["--bind".into(), root_dir.to_string(), root_dir.to_string()]);
         }
     }
+    if let Ok(val) = std::env::var("NIXSA_BWRAP_ARGS") {
+        args.extend(val.split_whitespace().map(String::from));
+    }
     Ok(args)
 }
 


### PR DESCRIPTION
Thanks for the great tool.

I have some case where I want to add additional `bwrap` arguments to the computed command line.
Would you be interested in adding support for that?

In this PR I've done it through an env variable but an argument to `nixsa` would work as well.

Feel free to close this PR if that's something you don't want to add.